### PR TITLE
Put to patch requests

### DIFF
--- a/lynk_up_server/lynk_up_server/serializers.py
+++ b/lynk_up_server/lynk_up_server/serializers.py
@@ -67,8 +67,15 @@ class GroupSerializer(serializers.ModelSerializer):
         friends_data = self.initial_data.get('friends_list', [])
         for friend_data in friends_data:
           friend_id = friend_data.get('friend_id')
-          friend = Friend.objects.get(friend_id=friend_id)
-          instance.friends.add(friend)
+          added_friend = Friend.objects.filter(friend_id=friend_id, user_id=instance.user.id)
+          accepted_friend = Friend.objects.filter(user_id=friend_id, friend_id=instance.user.id)
+
+          if added_friend.exists():
+            for friend in added_friend:
+              instance.friends.add(friend)
+          if accepted_friend.exists():
+            for friend in accepted_friend:
+              instance.friends.add(friend)
 
       return FriendsListSerializer(friends, many=True, read_only=True).data
 

--- a/lynk_up_server/lynk_up_server/serializers.py
+++ b/lynk_up_server/lynk_up_server/serializers.py
@@ -76,6 +76,9 @@ class GroupSerializer(serializers.ModelSerializer):
           if accepted_friend.exists():
             for friend in accepted_friend:
               instance.friends.add(friend)
+          # later: if added_friend.exists() and accepted_friend.exists():
+            # instance.friends.add(friend)
+            # explanation: will only want the ability to add a friend to a group / event if they have accepted the friend request
 
       return FriendsListSerializer(friends, many=True, read_only=True).data
 

--- a/lynk_up_server/lynk_up_server/views.py
+++ b/lynk_up_server/lynk_up_server/views.py
@@ -5,7 +5,6 @@ from rest_framework.response import Response
 from rest_framework import status
 from django.db import IntegrityError
 from django.views.decorators.http import require_http_methods
-from operator import attrgetter
 
 
 @api_view(['GET', 'POST'])
@@ -99,7 +98,7 @@ def event_list(request):
       return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
-@api_view(['GET', 'PUT', 'DELETE'])
+@api_view(['GET', 'PATCH', 'DELETE'])
 def event_detail(request, event_id):
   try:
     event = Event.objects.get(pk=event_id)
@@ -110,8 +109,8 @@ def event_detail(request, event_id):
     serializer = EventSerializer(event)
     return Response({"data": serializer.data})
 
-  elif request.method == 'PUT':
-    serializer = EventSerializer(event, data=request.data)
+  elif request.method == 'PATCH':
+    serializer = EventSerializer(event, data=request.data, partial=True)
     if serializer.is_valid():
       serializer.save()
       return Response(serializer.data)

--- a/lynk_up_server/lynk_up_server/views.py
+++ b/lynk_up_server/lynk_up_server/views.py
@@ -24,7 +24,7 @@ def user_list(request):
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-@api_view(['GET', 'PUT' 'DELETE'])
+@api_view(['GET', 'PATCH', 'DELETE'])
 def user_detail(request, user_id):
   try:
     user = User.objects.get(pk=user_id)
@@ -34,9 +34,9 @@ def user_detail(request, user_id):
   if request.method == 'GET':
     serializer = UserSerializer(user)
     return Response({"data": serializer.data})
-  
-  elif request.method == 'PUT':
-    serializer = UserSerializer(user, data=request.data)
+
+  elif request.method == 'PATCH':
+    serializer = UserSerializer(user, data=request.data, partial=True)
     if serializer.is_valid():
       serializer.save()
       return Response(serializer.data)

--- a/lynk_up_server/lynk_up_server/views.py
+++ b/lynk_up_server/lynk_up_server/views.py
@@ -62,7 +62,7 @@ def group_list(request):
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
   
 
-@api_view(['GET', 'PUT', 'DELETE'])
+@api_view(['GET', 'PATCH', 'DELETE'])
 def group_detail(request, group_id):
   try:
     group = Group.objects.get(pk=group_id)
@@ -73,8 +73,8 @@ def group_detail(request, group_id):
     serializer = GroupSerializer(group)
     return Response({"data": serializer.data})
   
-  elif request.method == 'PUT':
-    serializer = GroupSerializer(group, data=request.data)
+  elif request.method == 'PATCH':
+    serializer = GroupSerializer(group, data=request.data, partial=True, context={'request_method': 'PATCH'})
     if serializer.is_valid():
       serializer.save()
       return Response(serializer.data)
@@ -129,9 +129,8 @@ def friends(request, user_id):
     added_friends = user.added_friends()
     accepted_friends = user.accepted_friends()
     all_friends = added_friends + accepted_friends
-    sorted_friends = sorted(all_friends, key=attrgetter('full_name'))
 
-    serializer = FriendsListSerializer(sorted_friends, many=True)
+    serializer = FriendsListSerializer(all_friends, many=True)
     return Response(
       {"data": {"friends":serializer.data}}, status=200, content_type='application/json'
     )


### PR DESCRIPTION
## Issue(s)

Link Issue Here
    
## Type of change

    [] New feature
    [] Bug Fix
    [X] Refactor

## Description of Change

- Changed PUT requests to PATCH so records could be updated in segments
- Added note regarding group serializer method get_friends_list:

          if added_friend.exists():
            for friend in added_friend:
              instance.friends.add(friend)
          if accepted_friend.exists():
            for friend in accepted_friend:
              instance.friends.add(friend)

          # later: if added_friend.exists() and accepted_friend.exists():
            # instance.friends.add(friend)
            # explanation: will only want the ability to add a friend to a group / event if they have accepted the friend request
    